### PR TITLE
Add OAuth authentication

### DIFF
--- a/dist/common/index.js
+++ b/dist/common/index.js
@@ -13,4 +13,13 @@ Object.defineProperty(exports, "auth", {
   }
 });
 
+var _oauth = require("./oauth");
+
+Object.defineProperty(exports, "oauth", {
+  enumerable: true,
+  get: function () {
+    return _interopRequireDefault(_oauth).default;
+  }
+});
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/dist/common/oauth.js
+++ b/dist/common/oauth.js
@@ -1,0 +1,30 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = async function (config, token) {
+  let credentials;
+
+  if (typeof config === 'string') {
+    credentials = await (0, _fsExtra.readJSON)(config);
+  } else if (typeof config === 'object') {
+    credentials = config;
+  }
+
+  const {
+    client_secret,
+    client_id,
+    redirect_uris
+  } = credentials.installed;
+  this.client = new _googleAuthLibrary.OAuth2Client(client_id, client_secret, redirect_uris[0]);
+  await this.client.setCredentials(token);
+  return this;
+};
+
+var _fsExtra = require("fs-extra");
+
+var _googleAuthLibrary = require("google-auth-library");
+
+;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,9 +1,5 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
 var _googleapis = require("googleapis");
 
 var _mapValues = require("lodash/mapValues");
@@ -40,6 +36,8 @@ class Gootenberg {
   constructor(credentials) {
     _defineProperty(this, "auth", commonMethods.auth.bind(this));
 
+    _defineProperty(this, "oauth", commonMethods.oauth.bind(this));
+
     _defineProperty(this, "parse", (0, _mapValues2.default)(parseMethods, m => m.bind(this)));
 
     _defineProperty(this, "drive", (0, _mapValues2.default)(driveMethods, m => m.bind(this)));
@@ -55,4 +53,4 @@ class Gootenberg {
 
 }
 
-exports.default = Gootenberg;
+module.exports = Gootenberg;

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,17 @@
+# oauth(\[credentials\])
+
+Authenticate your `Gootenberg` with Google using OAuth. Create the `credentials.json` and `token.json` files by following [Google Sheets Quickstart](https://developers.google.com/sheets/api/quickstart/nodejs) (or [Docs Quickstart](https://developers.google.com/docs/api/quickstart/nodejs) or [Drive Quickstart](https://developers.google.com/drive/api/v3/quickstart/nodejs)).
+
+## Example
+```javascript
+import Gootenberg from 'gootenberg';
+import credentials from './credentials.json'
+import token from './token.json'
+
+async function myFunc(){
+  const goot = new Gootenberg();
+  await goot.oauth(credentials, token);
+}
+
+myFunc();
+```

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -1,1 +1,2 @@
 export { default as auth } from './auth';
+export { default as oauth } from './oauth';

--- a/src/common/oauth.js
+++ b/src/common/oauth.js
@@ -1,0 +1,22 @@
+import { readJSON } from 'fs-extra';
+import { OAuth2Client } from 'google-auth-library';
+
+export default async function(config, token) {
+  let credentials;
+
+  if (typeof config === 'string') {
+    credentials = await readJSON(config);
+  } else if (typeof config === 'object') {
+    credentials = config;
+  }
+
+  const {client_secret, client_id, redirect_uris} = credentials.installed;
+
+  this.client = new OAuth2Client(
+      client_id, client_secret, redirect_uris[0]);
+
+  await this.client.setCredentials(token);
+
+  return this;
+
+};

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ class Gootenberg {
   }
 
   auth = commonMethods.auth.bind(this);
+  oauth = commonMethods.oauth.bind(this);
 
   parse = mapValues(parseMethods, m => m.bind(this));
   drive = mapValues(driveMethods, m => m.bind(this));


### PR DESCRIPTION
I'm new to node and not great at Javascript, so please review. If you have questions you can find me on News Nerdery slack at @enactdev

I originally got this working by adding files to dist/ and consulting your auth.js file, [Google's Quickstart for sheets & node](https://developers.google.com/sheets/api/quickstart/nodejs) and the repository for [Google Auth Library](https://github.com/googleapis/google-auth-library-nodejs). 

Once it was working in the dist/ directory I added everything to the src/ directory and ran:

```
./node_modules/.bin/babel  src --out-dir dist --copy-file
```

Based on the build command in `package.json`.  I did not commit all changes that were created by the build command, only what was touched by my code. So the following were left out: 

 * dist/common/auth.js
 * dist/docs/test.js
 * dist/drive/test.js
 * dist/parse/test.js
 * dist/sheets/test.js
 * package-lock.json

