### PR TITLE
Get new suggestions only when fetching Google Docs

### DIFF
--- a/docs/docs.get.md
+++ b/docs/docs.get.md
@@ -3,6 +3,8 @@
 Get the content of a Google document in Google's [`Document`](https://developers.google.com/docs/api/reference/rest/v1/documents#Document) JSON type.
 
 - `id` `<String>`: The Id for a Google Doc (see [here](../README.md#usage))
+- `options` `<Object>`
+  - `suggestionsViewMode` `<String>`: How you would like to handle suggested edits from the Google Doc. (see [here](https://developers.google.com/docs/api/reference/rest/v1/documents#suggestionsviewmode))
 
 ## Example
 ```javascript
@@ -13,7 +15,9 @@ async function myFunc(){
   const goot = new Gootenberg();
   await goot.auth.jwt(credentials);
 
-  await goot.docs.get('MY_DOC_ID');
+  await goot.docs.get('MY_DOC_ID', {
+    suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS'
+  });
 }
 
 myFunc();

--- a/docs/docs.get.md
+++ b/docs/docs.get.md
@@ -4,7 +4,7 @@ Get the content of a Google document in Google's [`Document`](https://developers
 
 - `id` `<String>`: The Id for a Google Doc (see [here](../README.md#usage))
 - `options` `<Object>`
-  - `suggestionsViewMode` `<String>`: How you would like to handle suggested edits from the Google Doc. (see [here](https://developers.google.com/docs/api/reference/rest/v1/documents#suggestionsviewmode))
+  - `suggestionsViewMode` `<String>`: Defaults to `PREVIEW_WITHOUT_SUGGESTIONS`, but can be overridden to handle suggested edits in a different way. (see [the API docs](https://developers.google.com/docs/api/reference/rest/v1/documents#suggestionsviewmode)  for options).
 
 ## Example
 ```javascript
@@ -15,9 +15,7 @@ async function myFunc(){
   const goot = new Gootenberg();
   await goot.auth.jwt(credentials);
 
-  await goot.docs.get('MY_DOC_ID', {
-    suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS'
-  });
+  await goot.docs.get('MY_DOC_ID');
 }
 
 myFunc();

--- a/docs/parse.archie.md
+++ b/docs/parse.archie.md
@@ -3,6 +3,8 @@
 Downloads and parses an [ArchieML-formatted](http://archieml.org) Google Doc into JSON data.
 
 - `id` `<String>`: The Id for a Google Doc (see [here](../README.md#usage))
+- `options` `<Object>`
+  - `suggestionsViewMode` `<String>`: How you would like to handle suggested edits from the Google Doc. (see [here](https://developers.google.com/docs/api/reference/rest/v1/documents#suggestionsviewmode))
 
 ## Example
 ```javascript
@@ -13,7 +15,9 @@ async function myFunc(){
   const goot = new Gootenberg();
   await goot.auth.jwt(credentials);
 
-  const data = await goot.parse.archie('MY_DOC_ID');
+  const data = await goot.parse.archie('MY_DOC_ID', {
+    suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS'
+  });
 }
 
 myFunc();

--- a/docs/parse.archie.md
+++ b/docs/parse.archie.md
@@ -4,7 +4,7 @@ Downloads and parses an [ArchieML-formatted](http://archieml.org) Google Doc int
 
 - `id` `<String>`: The Id for a Google Doc (see [here](../README.md#usage))
 - `options` `<Object>`
-  - `suggestionsViewMode` `<String>`: How you would like to handle suggested edits from the Google Doc. (see [here](https://developers.google.com/docs/api/reference/rest/v1/documents#suggestionsviewmode))
+  - `suggestionsViewMode` `<String>`: Defaults to `PREVIEW_WITHOUT_SUGGESTIONS`, but can be overridden to handle suggested edits in a different way. (see [the API docs](https://developers.google.com/docs/api/reference/rest/v1/documents#suggestionsviewmode)  for options).
 
 ## Example
 ```javascript
@@ -15,9 +15,7 @@ async function myFunc(){
   const goot = new Gootenberg();
   await goot.auth.jwt(credentials);
 
-  const data = await goot.parse.archie('MY_DOC_ID', {
-    suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS'
-  });
+  const data = await goot.parse.archie('MY_DOC_ID');
 }
 
 myFunc();

--- a/src/docs/get.js
+++ b/src/docs/get.js
@@ -2,6 +2,7 @@ export default async function get(docId) {
   const { data } = await this.docsAPI.documents.get({
     auth: this.client,
     documentId: docId,
+    suggestionsViewMode: 'PREVIEW_SUGGESTIONS_ACCEPTED'
   });
 
   return data;

--- a/src/docs/get.js
+++ b/src/docs/get.js
@@ -1,8 +1,11 @@
-export default async function get(docId) {
+export default async function get(
+  docId,
+  { suggestionsViewMode = 'PREVIEW_WITHOUT_SUGGESTIONS' } = {},
+) {
   const { data } = await this.docsAPI.documents.get({
     auth: this.client,
     documentId: docId,
-    suggestionsViewMode: 'PREVIEW_SUGGESTIONS_ACCEPTED'
+    suggestionsViewMode,
   });
 
   return data;

--- a/src/parse/archie/index.js
+++ b/src/parse/archie/index.js
@@ -2,10 +2,15 @@ import validateArgs from 'aproba';
 import archieml from 'archieml';
 import docsToArchie from './_docsToArchie';
 
-export default async function parseArchie(docId) {
+export default async function parseArchie(
+  docId,
+  { suggestionsViewMode = 'PREVIEW_WITHOUT_SUGGESTIONS' } = {},
+) {
   validateArgs('S', [docId]);
 
-  const archie = await this.docs.get(docId);
+  const archie = await this.docs.get(docId, {
+    suggestionsViewMode: suggestionsViewMode
+  });
   const parsed = docsToArchie(archie);
   return archieml.load(parsed);
 }

--- a/src/parse/archie/index.js
+++ b/src/parse/archie/index.js
@@ -4,12 +4,12 @@ import docsToArchie from './_docsToArchie';
 
 export default async function parseArchie(
   docId,
-  { suggestionsViewMode = 'PREVIEW_WITHOUT_SUGGESTIONS' } = {},
+  { suggestionsViewMode } = {},
 ) {
   validateArgs('S', [docId]);
 
   const archie = await this.docs.get(docId, {
-    suggestionsViewMode: suggestionsViewMode
+    suggestionsViewMode,
   });
   const parsed = docsToArchie(archie);
   return archieml.load(parsed);


### PR DESCRIPTION
At The Philadelphia Inquirer we've started editing in archie docs. However, we use Gootenberg to fetch and parse copy from Google Docs. And Gootenberg's Google Doc `get` function doesn't specify a [`suggestionsViewMode`](https://developers.google.com/docs/api/reference/rest/v1/documents#suggestionsviewmode), which means it's defaulting to returning both the new suggestions and original suggested deletions. Which means the resulting copy is a garbled mess of two versions.

Here I've added that parameter to the request so we only get the newer suggestions only. This feels like a more logical option over getting both.